### PR TITLE
SHA384 and SHA512 blocksize fixes

### DIFF
--- a/lib/Pass/OTP.pm
+++ b/lib/Pass/OTP.pm
@@ -73,10 +73,12 @@ sub hotp {
     my ($hex) = $C->as_hex =~ /^0x(.*)/;
     $hex = "0" x (16 - length($hex)) . $hex;
 
-    my $digest = Digest::SHA->new($options{algorithm} =~ /sha(\d+)/);
+    my ($algorithm) = $options{algorithm} =~ /sha(\d+)/;
+    my $digest = Digest::SHA->new($algorithm);
     my $hmac   = Digest::HMAC->new(
         $options{base32} ? decode_base32($options{secret} =~ s/ //gr) : pack('H*', $options{secret}),
         $digest,
+        $algorithm < 384? 64 : 128,
     );
     $hmac->add(pack 'H*', $hex);
     my $hash = $hmac->digest;

--- a/t/oathtool.t
+++ b/t/oathtool.t
@@ -95,6 +95,15 @@ t(
     now       => `date -d'2009-02-13 23:31:30 UTC' +%s`,
 );
 
+t(
+"$oathtool --totp=sha512 --digits=8 --now '2009-02-13 23:31:30 UTC' 3132333435363738393031323334353637383930313233343536373839303132",
+    secret    => "3132333435363738393031323334353637383930313233343536373839303132",
+    type      => 'totp',
+    algorithm => 'sha512',
+    digits    => 8,
+    now       => `date -d'2009-02-13 23:31:30 UTC' +%s`,
+);
+
 TODO: {
     local $TODO = "Parameter --window not implemented";
     t(
@@ -117,4 +126,4 @@ TODO: {
     );
 }
 
-done_testing(13);
+done_testing(14);

--- a/t/totp-test-vectors.t
+++ b/t/totp-test-vectors.t
@@ -1,0 +1,66 @@
+use Test::More;
+
+use utf8;
+use strict;
+use warnings;
+
+require_ok 'Pass::OTP';
+
+# Based on the test vectors from RFC6238
+
+my %seeds = (
+    sha1   => '3132333435363738393031323334353637383930',
+    sha256 => '3132333435363738393031323334353637383930'.
+              '313233343536373839303132',
+    sha512 => '3132333435363738393031323334353637383930'.
+              '3132333435363738393031323334353637383930'.
+              '3132333435363738393031323334353637383930'.
+              '31323334',
+);
+
+sub is_totp {
+    my %opts = (@_);
+
+    is(
+        Pass::OTP::otp(
+        secret    => $seeds{$opts{algorithm}},
+        algorithm => $opts{algorithm},
+        now       => $opts{now},
+        digits    => 8,
+        type      => 'totp'),
+        $opts{totp},
+        "Test vector with time (sec) $opts{now} on mode $opts{algorithm}"
+    );
+}
+
+is_totp(now => 59, algorithm => 'sha1',   totp => '94287082');
+is_totp(now => 59, algorithm => 'sha256', totp => '46119246');
+is_totp(now => 59, algorithm => 'sha512', totp => '90693936');
+
+
+is_totp(now => 1111111109, algorithm => 'sha1',   totp => '07081804');
+is_totp(now => 1111111109, algorithm => 'sha256', totp => '68084774');
+is_totp(now => 1111111109, algorithm => 'sha512', totp => '25091201');
+
+
+is_totp(now => 1111111111, algorithm => 'sha1',   totp => '14050471');
+is_totp(now => 1111111111, algorithm => 'sha256', totp => '67062674');
+is_totp(now => 1111111111, algorithm => 'sha512', totp => '99943326');
+
+
+is_totp(now => 1234567890, algorithm => 'sha1',   totp => '89005924');
+is_totp(now => 1234567890, algorithm => 'sha256', totp => '91819424');
+is_totp(now => 1234567890, algorithm => 'sha512', totp => '93441116');
+
+
+is_totp(now => 2000000000, algorithm => 'sha1',   totp => '69279037');
+is_totp(now => 2000000000, algorithm => 'sha256', totp => '90698825');
+is_totp(now => 2000000000, algorithm => 'sha512', totp => '38618901');
+
+
+is_totp(now => 20000000000, algorithm => 'sha1',   totp => '65353130');
+is_totp(now => 20000000000, algorithm => 'sha256', totp => '77737706');
+is_totp(now => 20000000000, algorithm => 'sha512', totp => '47863826');
+
+
+done_testing(19);


### PR DESCRIPTION
The 384 and 512 variants of SHA2 use a larger block size than the other variants and it needs to be passed to Digest::HMAC as it defaults to one compatible with SHA1 and SHA-256.
