### PR TITLE
Switch to MIME::Base32

### DIFF
--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install dependencies
         run: >-
           sudo apt-get install
-          libconvert-base32-perl
+          libmime-base32-perl
           libdigest-hmac-perl
           libdigest-sha-perl
           libmath-bigint-perl

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
         'Test::More' => '0',
     },
     PREREQ_PM => {
-        'Convert::Base32' => '0',
+        'MIME::Base32' => '0',
         'Digest::HMAC' => '0',
         'Digest::SHA' => '0',
         'Math::BigInt' => '1.999806',

--- a/lib/Pass/OTP.pm
+++ b/lib/Pass/OTP.pm
@@ -20,7 +20,7 @@ use utf8;
 use strict;
 use warnings;
 
-use Convert::Base32 qw(decode_base32);
+use MIME::Base32 qw(decode_base32);
 use Digest::HMAC;
 use Digest::SHA;
 use Math::BigInt;


### PR DESCRIPTION
This is used by [URI](https://metacpan.org/dist/URI) for [URI::otpauth](https://metacpan.org/pod/URI::otpauth), so it is far more likely than Convert::Base32 to already be installed.

(MIME::Base32 itself also has only core dependencies, whereas Convert::Base32 depends on the rather iffy Test::Exception, which in turns depends on the even iffier Sub::Uplevel.)

Both modules export the same functions with the same signatures under the same names, so this is ends up being a trivial patch.