### PR TITLE
Support reading OTP secret from stdin

### DIFF
--- a/bin/oathtool
+++ b/bin/oathtool
@@ -6,7 +6,7 @@ oathtool - alternative Perl implementation of oathtool(1), one-time password too
 
 =head1 SYNOPSIS
 
-oathtool [options] KEY | URI
+oathtool [options] KEY | URI | -
 
     Options:
         -h, --help
@@ -20,6 +20,8 @@ oathtool [options] KEY | URI
         -S, --start-time=UNIX_TIME
         -N, --now=UNIX_TIME
         -d, --digits=INT
+
+    If invoked with '-', the key or URI is read from standard input.
 
     URI: otpauth://....
 
@@ -39,7 +41,6 @@ our $VERSION = '1.2';
 
 pod2usage(2) if @ARGV == 0;
 my %options;
-$options{secret} = pop if $ARGV[-1] !~ /^-/;
 
 Getopt::Long::Configure(qw(auto_version no_ignore_case));
 GetOptions(\%options,
@@ -55,7 +56,14 @@ GetOptions(\%options,
     'digits|d=i',
 ) || pod2usage(2);
 
-pod2usage(2) if @ARGV == 0 and not defined $options{secret};
+if ($ARGV[0] eq "-") {
+    $options{secret} = <>;
+    chomp($options{secret});
+} elsif (@ARGV == 0) {
+    pod2usage(2);
+} else {
+    $options{secret} = $ARGV[0];
+}
 
 $options{type} = 'totp' if defined $options{totp};
 $options{algorithm} = $options{totp} if defined $options{totp} and $options{totp} ne '';

--- a/bin/otptool
+++ b/bin/otptool
@@ -6,7 +6,11 @@ otptool - one-time password tool
 
 =head1 SYNOPSIS
 
-otptool otpauth://...
+otptool URI | -
+
+    URI: otpauth://
+
+    If invoked with '-', the URI is read from standard input.
 
 =cut
 
@@ -21,6 +25,7 @@ use Pass::OTP qw(otp);
 use Pass::OTP::URI qw(parse);
 
 our $VERSION = $Pass::OTP::VERSION;
+my $uri = "";
 
 Getopt::Long::Configure(qw(auto_version));
 GetOptions(
@@ -28,8 +33,16 @@ GetOptions(
 ) || pod2usage(2);
 
 pod2usage(2) if @ARGV == 0;
-pod2usage(2) if $ARGV[0] !~ m#^otpauth://#;
-printf("%s\n", otp(parse($ARGV[0])));
+
+if ($ARGV[0] eq "-") {
+    $uri = <>;
+} elsif ($ARGV[0] =~ m#^otpauth://#) {
+    $uri = $ARGV[0];
+} else {
+    pod2usage(2);
+}
+
+printf("%s\n", otp(parse($uri)));
 exit 0;
 
 __END__


### PR DESCRIPTION
Reading the OTP secret from stdin is slightly more secure than passing it as a command line argument, since command line arguments can usually be seen by other processes and other users.

In particular, this will allow pass-otp to use `otptool` to handle Steam 2FA keys securely, which aren't supported by oath-toolkit's `oathtool`. pass-otp already prefers `oathtool` over `otptool` if both are installed because `oathtool` supports reading secrets from stdin, but this means users can't use Steam OTP keys in pass-otp without workarounds.